### PR TITLE
Update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,11 +28,19 @@
 [build.environment]
   NODE_VERSION = "18"
 
-
+#cant find a sliver bullet for the display problem let's just redirect the waiver page out to google form alone
+#i put a link to jump back after submission
+#another note: i bypassed the captcha using brevo, 300 emails per day should be enough
 # URL aliases for cleaner URLs
 [[redirects]]
   from = "/waiver"
-  to = "/pages/waiver.html"
+  to = "https://docs.google.com/forms/d/e/1FAIpQLSf_MCkZ95evnMw7oDOgIHocWRAnmq0vNKyPIJMu4tkpy5WxHA/viewform?usp=header"
+  #to = "/pages/waiver.html"
+  status = 301 
+
+[[redirects]]
+  from = "/waiver"
+  to = "https://docs.google.com/forms/d/e/1FAIpQLSf_MCkZ95evnMw7oDOgIHocWRAnmq0vNKyPIJMu4tkpy5WxHA/viewform?usp=header"
   status = 301 
 
 # Main redirect for single-page app
@@ -40,3 +48,5 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+


### PR DESCRIPTION
#cant find a sliver bullet for the display problem let's just redirect the waiver page out to google form alone #i put a link to jump back after submission
#another note: i bypassed the captcha using brevo, 300 emails per day should be enough # URL aliases for cleaner URLs